### PR TITLE
Add product page link and move download in order details

### DIFF
--- a/themes/classic/templates/customer/_partials/order-detail-no-return.tpl
+++ b/themes/classic/templates/customer/_partials/order-detail-no-return.tpl
@@ -37,12 +37,15 @@
         <tr>
           <td>
             <strong>
-              <a {if isset($product.download_link)}href="{$product.download_link}"{/if}>
+              <a href="{$urls.pages.product}&id_product={$product.id_product}">
                 {$product.name}
               </a>
             </strong><br/>
             {if $product.product_reference}
               {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
+            {/if}
+            {if isset($product.download_link)}
+              <a href="{$product.download_link}">{l s='download' d='Shop.Theme.Catalog'}</a><br/>
             {/if}
             {if $product.customizations}
               {foreach from=$product.customizations item="customization"}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add product page link in order details into name on product name and download link as separate thing.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24702
| How to test?      | Go to order page from customer account.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
